### PR TITLE
removed photologue/ from urls.py

### DIFF
--- a/wsgi/odyssy/odyssy/urls.py
+++ b/wsgi/odyssy/odyssy/urls.py
@@ -29,6 +29,5 @@ urlpatterns = [
     url(r'^events/', include('events.urls')),
     url(r'^news/', include('news.urls')),
     url(r'^announcement/', include('announcement.urls')),
-    url(r'^photologue/', include('photologue.urls', namespace='photologue')),
     url(r'^', include('basic.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
No need of keeping `photologue/` in `urls.py` because upload/delete is can be managed using django-admin.